### PR TITLE
[#ERNEST-78] : Extends adapter to manage route53 and elasticsearch

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,9 +18,7 @@ var nc *nats.Conn
 var natsErr error
 
 func main() {
-	// TODO : Types probably need to be get from the config with getConnectorTypes
-	//types := []string{"elb", "ebs", "s3", "rds", "route53", "elasticsearch"}
-	components := []string{"vpc", "elb", "network", "instance", "firewall", "nat", "s3"}
+	components := []string{"vpc", "elb", "network", "instance", "firewall", "nat", "s3", "route53", "elasticsearch"}
 	types := []string{"aws-fake", "vcloud-fake", "aws", "vcloud", "fake"}
 	nc = ecc.NewConfig(os.Getenv("NATS_URI")).Nats()
 


### PR DESCRIPTION
Fixes: https://github.com/ernestio/ernest/issues/79
Fixes: https://github.com/ernestio/ernest/issues/100

By extending the generic adapter to manage route53 and elasticsearch 